### PR TITLE
Only register the panel if it is the active panel

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -42,6 +42,8 @@ export default class Panel extends React.Component {
   }
 
   render() {
+    if(!this.props.active) return (null);
+
     const { theme, themes } = this.state
 
     if (!theme) return <div>Addon is initialising</div>

--- a/src/register.js
+++ b/src/register.js
@@ -2,12 +2,11 @@ import React from 'react'
 import addons from '@storybook/addons'
 import Panel from './Panel'
 
-
 addons.register('storybook-styled-components', api => {
   const channel = addons.getChannel();
 
   addons.addPanel('storybook-styled-components/panel', {
     title: 'Theme Picker',
-    render: () => <Panel channel={channel} api={api} key="theme-picker-panel" />,
+    render: (panelState) => <Panel channel={channel} api={api} key="theme-picker-panel" active={panelState.active} />,
   })
 })


### PR DESCRIPTION
Note: the value passed in to `render`  is an object with a key of ‘active’ set to `true` if the panel is active or `false` if not. Instead of rendering the panel every time any panel becomes active we only render it when this is the active panel.

From the [docs](https://storybook.js.org/addons/writing-addons/):

> Multiple addons can be loaded, but only a single panel can be shown, the render function will receive an active prop, which is true if the addon is shown. It is up to you to decide if this mean your component must be unmounted, or just visually hidden. This allows you to keep state but unmount expensive renderings.

Closes #7